### PR TITLE
feat: add practical use-case examples showcasing framework value

### DIFF
--- a/application/admin/actions/auth.action.php
+++ b/application/admin/actions/auth.action.php
@@ -1,0 +1,54 @@
+<?php
+
+/**
+ * 后台登录/登出
+ * GET|POST /admin/auth/login   → 登录页
+ * GET      /admin/auth/logout  → 登出
+ */
+class admin_auth_action extends admin_base_action
+{
+    protected $requireAdmin = false;
+    protected $csrfValidate = false;
+
+    public function invoke()
+    {
+        $sub = $this->getParam('action', 'login');
+
+        if ($sub === 'logout') {
+            session_destroy();
+            redirect('/admin/auth/login');
+        }
+
+        if (IS_POST) {
+            $this->doLogin();
+        } else {
+            $this->assign('error', '');
+            $this->render('auth/login', 'auth_layout');
+        }
+    }
+
+    private function doLogin(): void
+    {
+        $username = $this->getParam('username', '');
+        $password = $this->getParam('password', '');
+
+        $db   = DB();
+        $user = $db->get('admins', ['id', 'username', 'password', 'role'], ['username' => $username]);
+
+        if (!$user || !password_verify($password, $user['password'])) {
+            $this->assign('error', '账号或密码错误');
+            $this->render('auth/login', 'auth_layout');
+            return;
+        }
+
+        $_SESSION['admin_id']   = $user['id'];
+        $_SESSION['admin_name'] = $user['username'];
+        $_SESSION['admin_role'] = $user['role'];
+
+        $db->update('admins', ['last_login_at' => date('Y-m-d H:i:s')], ['id' => $user['id']]);
+
+        L("管理员登录: id={$user['id']} name={$user['username']}", ['ip' => get_client_ip()], 'INFO');
+
+        redirect('/admin/dashboard');
+    }
+}

--- a/application/admin/actions/dashboard.action.php
+++ b/application/admin/actions/dashboard.action.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * 管理后台首页：数据看板
+ * GET /admin/dashboard
+ */
+class admin_dashboard_action extends admin_base_action
+{
+    protected $csrfValidate = false;
+
+    public function invoke()
+    {
+        $db    = DB();
+        $today = date('Y-m-d');
+        $week  = date('Y-m-d', strtotime('-7 days'));
+
+        // 多项统计并行查询（Medoo 本身不支持 async，但写法整洁）
+        $stats = [
+            'total_users'    => $db->count('users', ['status' => 1]),
+            'new_users_week' => $db->count('users', ['created_at[>=]' => $week]),
+            'total_posts'    => $db->count('blog_posts', ['status' => 1]),
+            'new_posts_today'=> $db->count('blog_posts', ['created_at[>=]' => $today . ' 00:00:00']),
+            'total_comments' => $db->count('blog_comments'),
+        ];
+
+        // 近7天每日新用户趋势（用原生 SQL）
+        $trend = $db->query(
+            "SELECT DATE(created_at) AS day, COUNT(*) AS cnt
+               FROM users
+              WHERE created_at >= :week
+           GROUP BY DATE(created_at)
+           ORDER BY day ASC",
+            [':week' => $week]
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        $this->assign('stats', $stats);
+        $this->assign('trend', $trend);
+        $this->assign('admin', $this->adminUser());
+        $this->render('dashboard/index', 'layout');
+    }
+}

--- a/application/admin/actions/user.action.php
+++ b/application/admin/actions/user.action.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * 用户管理
+ * GET /admin/user             → 列表（支持 keyword/page 参数）
+ * GET /admin/user?export=csv  → 导出 CSV
+ * POST /admin/user            → 禁用/启用用户（传 id + status）
+ */
+class admin_user_action extends admin_base_action
+{
+    public function invoke()
+    {
+        if ($this->getParam('export') === 'csv') {
+            $this->exportCsv();
+            return;
+        }
+
+        if (IS_POST) {
+            $this->toggleStatus();
+            return;
+        }
+
+        $this->listUsers();
+    }
+
+    private function listUsers(): void
+    {
+        $keyword = trim($this->getParam('keyword', ''));
+        $page    = max(1, (int) $this->getParam('page', 1));
+        $perPage = 20;
+        $offset  = ($page - 1) * $perPage;
+
+        $db    = DB();
+        $where = ['status[!]' => -1];   // 排除已删除
+
+        if ($keyword) {
+            $where['OR'] = [
+                'username[~]' => $keyword,
+                'email[~]'    => $keyword,
+            ];
+        }
+
+        $total = $db->count('users', $where);
+        $users = $db->select('users', [
+            'id', 'username', 'email', 'status', 'created_at', 'last_login_at',
+        ], array_merge($where, [
+            'ORDER' => ['created_at' => 'DESC'],
+            'LIMIT' => [$offset, $perPage],
+        ]));
+
+        $this->assign('users',     $users ?: []);
+        $this->assign('keyword',   $keyword);
+        $this->assign('page',      $page);
+        $this->assign('totalPage', (int) ceil($total / $perPage));
+        $this->assign('total',     $total);
+        $this->render('user/list', 'layout');
+    }
+
+    private function toggleStatus(): void
+    {
+        $id     = (int) $this->getParam('id', 0);
+        $status = (int) $this->getParam('status', 0);
+
+        if (!$id || !in_array($status, [0, 1], true)) {
+            $this->error('参数错误', 422, true);
+        }
+
+        DB()->update('users', ['status' => $status], ['id' => $id]);
+
+        L("管理员修改用户状态: uid={$id} status={$status}", ['by' => $this->adminUser()['id']], 'INFO');
+
+        $this->correct([], '操作成功');
+    }
+
+    private function exportCsv(): void
+    {
+        $db    = DB();
+        $users = $db->select('users', ['id', 'username', 'email', 'status', 'created_at'], [
+            'ORDER' => ['id' => 'ASC'],
+        ]);
+
+        $rows = [['ID', '用户名', '邮箱', '状态', '注册时间']];
+        foreach ($users as $u) {
+            $rows[] = [
+                $u['id'],
+                $u['username'],
+                $u['email'],
+                $u['status'] === 1 ? '正常' : '禁用',
+                $u['created_at'],
+            ];
+        }
+
+        export_csv('users_' . date('YmdHis') . '.csv', $rows);  // 自动下载并 exit
+    }
+}

--- a/application/admin/admin.boot.php
+++ b/application/admin/admin.boot.php
@@ -1,24 +1,33 @@
 <?php
 
-PlumePHP::app()->path(PLUME_PHP_PATH.DS.'library'.DS.'core');
+PlumePHP::app()->path(PLUME_PHP_PATH . DS . 'library' . DS . 'core');
 
-/**
- * abstract class for wx
- */
-abstract class web_base_action extends \Plume\Libs\Action
+abstract class admin_base_action extends \Plume\Libs\Action
 {
-    /**
-     * csrf验证
-     * @var bool
-     */
-    protected $csrfValidate = false;
-    public function init()
+    protected $csrfValidate = true;
+    protected $requireAdmin = true;
+
+    public function init(): bool
     {
+        if (!$this->requireAdmin) {
+            return true;
+        }
+
+        if (empty($_SESSION['admin_id'])) {
+            if (IS_AJAX) {
+                $this->error('请先登录', 401, true);
+            }
+            redirect('/admin/auth/login');
+        }
+
+        // 超级简单的角色检查
+        if (empty($_SESSION['admin_role']) || $_SESSION['admin_role'] !== 'admin') {
+            $this->error('权限不足', 403, IS_AJAX);
+        }
+
         return true;
     }
-    /**
-     * execute方法
-     */
+
     public function execute()
     {
         if ($this->init()) {
@@ -26,27 +35,22 @@ abstract class web_base_action extends \Plume\Libs\Action
         }
     }
 
-    /**
-     * Execute the action
-     *
-     * @abstract
-     * @access public
-     * @return bool True if the action was executed or false when not executed
-     */
     abstract public function invoke();
+
+    protected function adminUser(): array
+    {
+        return [
+            'id'   => $_SESSION['admin_id']   ?? 0,
+            'name' => $_SESSION['admin_name'] ?? '',
+        ];
+    }
 }
 
-class web_base_cmd
+class admin_base_cmd
 {
-    /**
-     * 日志记录
-     */
-    protected function output($msg, $isEcho = true)
+    protected function log(string $msg): void
     {
-        if ($isEcho) {
-            echo $msg, PHP_EOL;
-        }
-
-        PlumeLog::info($msg);
+        echo '[' . date('H:i:s') . '] ' . $msg . PHP_EOL;
+        L($msg, [], 'INFO');
     }
 }

--- a/application/api/actions/article.action.php
+++ b/application/api/actions/article.action.php
@@ -1,0 +1,128 @@
+<?php
+
+/**
+ * 文章资源 REST API（需 Bearer Token）
+ *
+ * GET    /api/article         → 列表
+ * GET    /api/article?id=1    → 详情
+ * POST   /api/article/create  → 创建
+ * POST   /api/article/update  → 更新（传 id）
+ * POST   /api/article/delete  → 删除（传 id）
+ */
+class api_article_action extends api_base_action
+{
+    protected $requireAuth = true;
+
+    // 创建/更新共用验证规则（validate() 里按方法选择）
+    private array $writeRules = [
+        'title'   => 'required|string|minLen:4|maxLen:200',
+        'content' => 'required|string|minLen:10',
+    ];
+
+    public function invoke()
+    {
+        $sub = $this->getParam('action', '');
+
+        match ($sub) {
+            'create' => $this->create(),
+            'update' => $this->update(),
+            'delete' => $this->delete(),
+            default  => $this->index(),
+        };
+    }
+
+    private function index(): void
+    {
+        $id = (int) $this->getParam('id', 0);
+
+        if ($id > 0) {
+            $row = DB()->get('articles', '*', ['id' => $id]);
+            $row ? $this->correct($row) : $this->error('Not Found', 404, true);
+            return;
+        }
+
+        $page    = max(1, (int) $this->getParam('page', 1));
+        $perPage = min(50, max(1, (int) $this->getParam('per_page', 20)));
+        $offset  = ($page - 1) * $perPage;
+
+        $db    = DB();
+        $total = $db->count('articles', ['author_id' => $this->authUser['uid']]);
+        $rows  = $db->select('articles', [
+            'id', 'title', 'status', 'created_at', 'updated_at',
+        ], [
+            'author_id' => $this->authUser['uid'],
+            'ORDER'     => ['created_at' => 'DESC'],
+            'LIMIT'     => [$offset, $perPage],
+        ]);
+
+        $this->correct([
+            'total'    => $total,
+            'page'     => $page,
+            'per_page' => $perPage,
+            'items'    => $rows ?: [],
+        ]);
+    }
+
+    private function create(): void
+    {
+        $this->rules = $this->writeRules;
+        $errors = $this->validate();
+        if ($errors) {
+            $this->error(reset($errors), 422, true);
+        }
+
+        $id = DB()->insert('articles', [
+            'title'      => $this->getParam('title'),
+            'content'    => $this->getParam('content'),
+            'author_id'  => $this->authUser['uid'],
+            'status'     => 1,
+            'created_at' => date('Y-m-d H:i:s'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $this->correct(['id' => $id], '创建成功');
+    }
+
+    private function update(): void
+    {
+        $id = (int) $this->getParam('id', 0);
+        if (!$id) {
+            $this->error('缺少 id', 422, true);
+        }
+
+        // 确保只能编辑自己的文章
+        $db  = DB();
+        $row = $db->get('articles', ['id'], ['id' => $id, 'author_id' => $this->authUser['uid']]);
+        if (!$row) {
+            $this->error('无权操作或文章不存在', 403, true);
+        }
+
+        $fields = array_filter([
+            'title'      => $this->getParam('title'),
+            'content'    => $this->getParam('content'),
+            'updated_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $db->update('articles', $fields, ['id' => $id]);
+        $this->correct([], '更新成功');
+    }
+
+    private function delete(): void
+    {
+        $id = (int) $this->getParam('id', 0);
+        if (!$id) {
+            $this->error('缺少 id', 422, true);
+        }
+
+        $db  = DB();
+        $row = $db->get('articles', ['id'], ['id' => $id, 'author_id' => $this->authUser['uid']]);
+        if (!$row) {
+            $this->error('无权操作或文章不存在', 403, true);
+        }
+
+        $db->delete('articles', ['id' => $id]);
+        L("文章删除: id={$id}", ['uid' => $this->authUser['uid']], 'INFO');
+
+        $this->correct([], '删除成功');
+    }
+}

--- a/application/api/actions/user.action.php
+++ b/application/api/actions/user.action.php
@@ -1,0 +1,116 @@
+<?php
+
+/**
+ * 用户 API
+ *
+ * POST /api/user/register  注册
+ * POST /api/user/login     登录
+ * GET  /api/user/profile   当前用户信息（需 Token）
+ */
+class api_user_action extends api_base_action
+{
+    protected $requireAuth = false;
+
+    protected array $registerRules = [
+        'username' => 'required|string|minLen:3|maxLen:30',
+        'email'    => 'required|email',
+        'password' => 'required|string|minLen:8|maxLen:64',
+    ];
+
+    public function invoke()
+    {
+        $controller = $this->getParam('action', '') ?: 'profile';
+
+        // 手动路由到子方法
+        match ($controller) {
+            'register' => $this->register(),
+            'login'    => $this->login(),
+            'profile'  => $this->profile(),
+            default    => $this->error('Not Found', 404, true),
+        };
+    }
+
+    private function register(): void
+    {
+        $this->rules = $this->registerRules;
+        $errors = $this->validate();
+        if ($errors) {
+            $this->error(reset($errors), 422, true);
+        }
+
+        $username = $this->getParam('username');
+        $email    = $this->getParam('email');
+        $password = $this->getParam('password');
+
+        $db = DB();
+        if ($db->has('users', ['OR' => ['username' => $username, 'email' => $email]])) {
+            $this->error('用户名或邮箱已存在', 409, true);
+        }
+
+        $uid = $db->insert('users', [
+            'username'   => $username,
+            'email'      => $email,
+            'password'   => password_hash($password, PASSWORD_BCRYPT),
+            'status'     => 1,
+            'created_at' => date('Y-m-d H:i:s'),
+        ]);
+
+        $token = $this->makeToken((int) $uid, $username);
+
+        L("用户注册: uid={$uid} username={$username}", [], 'INFO');
+
+        $this->correct(['uid' => $uid, 'token' => $token], '注册成功');
+    }
+
+    private function login(): void
+    {
+        $login    = $this->getParam('login', '');    // username 或 email
+        $password = $this->getParam('password', '');
+
+        if (!$login || !$password) {
+            $this->error('账号和密码不能为空', 422, true);
+        }
+
+        $db   = DB();
+        $user = $db->get('users', ['id', 'username', 'password', 'status'], [
+            'OR' => ['username' => $login, 'email' => $login],
+        ]);
+
+        if (!$user || !password_verify($password, $user['password'])) {
+            $this->error('账号或密码错误', 401, true);
+        }
+
+        if ($user['status'] !== 1) {
+            $this->error('账号已被禁用', 403, true);
+        }
+
+        $db->update('users', ['last_login_at' => date('Y-m-d H:i:s')], ['id' => $user['id']]);
+
+        $token = $this->makeToken((int) $user['id'], $user['username']);
+
+        $this->correct([
+            'uid'      => $user['id'],
+            'username' => $user['username'],
+            'token'    => $token,
+        ], '登录成功');
+    }
+
+    private function profile(): void
+    {
+        // 需要 Token 鉴权，临时覆盖 requireAuth 并重新校验
+        $this->requireAuth = true;
+        if (!$this->init()) {
+            return;
+        }
+
+        $uid  = $this->authUser['uid'];
+        $db   = DB();
+        $user = $db->get('users', ['id', 'username', 'email', 'created_at', 'last_login_at'], ['id' => $uid]);
+
+        if (!$user) {
+            $this->error('用户不存在', 404, true);
+        }
+
+        $this->correct($user);
+    }
+}

--- a/application/api/api.boot.php
+++ b/application/api/api.boot.php
@@ -1,0 +1,66 @@
+<?php
+
+PlumePHP::app()->path(PLUME_PHP_PATH . DS . 'library' . DS . 'core');
+
+abstract class api_base_action extends \Plume\Libs\Action
+{
+    protected $csrfValidate = false;
+    protected $requireAuth  = true;
+
+    protected ?array $authUser = null;
+
+    public function init(): bool
+    {
+        header('Content-Type: application/json; charset=utf-8');
+
+        if (!$this->requireAuth) {
+            return true;
+        }
+
+        $token = $this->getBearerToken();
+        if (!$token) {
+            $this->error('Missing Authorization header', 401, true);
+        }
+
+        $payload = authcode($token, 'DECODE', C('API_TOKEN_SECRET') ?: 'plume-api-secret');
+        if (!$payload) {
+            $this->error('Invalid or expired token', 401, true);
+        }
+
+        $data = json_decode($payload, true);
+        if (!$data || empty($data['uid']) || $data['exp'] < time()) {
+            $this->error('Token expired', 401, true);
+        }
+
+        $this->authUser = $data;
+        return true;
+    }
+
+    public function execute()
+    {
+        if ($this->init()) {
+            return $this->invoke();
+        }
+    }
+
+    abstract public function invoke();
+
+    private function getBearerToken(): ?string
+    {
+        $header = $_SERVER['HTTP_AUTHORIZATION'] ?? '';
+        if (strncasecmp($header, 'Bearer ', 7) === 0) {
+            return substr($header, 7);
+        }
+        return null;
+    }
+
+    protected function makeToken(int $uid, string $name, int $ttl = 86400 * 7): string
+    {
+        $payload = json_encode([
+            'uid'  => $uid,
+            'name' => $name,
+            'exp'  => time() + $ttl,
+        ]);
+        return authcode($payload, 'ENCODE', C('API_TOKEN_SECRET') ?: 'plume-api-secret', $ttl);
+    }
+}

--- a/application/batch/batch.boot.php
+++ b/application/batch/batch.boot.php
@@ -1,0 +1,19 @@
+<?php
+
+PlumePHP::app()->path(PLUME_PHP_PATH . DS . 'library' . DS . 'core');
+
+class batch_base_cmd
+{
+    protected function log(string $msg, string $level = 'INFO'): void
+    {
+        echo '[' . date('H:i:s') . "][{$level}] {$msg}" . PHP_EOL;
+        L($msg, [], $level);
+    }
+
+    protected function confirm(string $question): bool
+    {
+        echo $question . ' [y/N] ';
+        $answer = strtolower(trim(fgets(STDIN)));
+        return $answer === 'y' || $answer === 'yes';
+    }
+}

--- a/application/batch/console/cleanup.cmd.php
+++ b/application/batch/console/cleanup.cmd.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * 过期数据清理命令
+ *
+ * 用法:
+ *   php public/index.php -m batch -c cleanup
+ *   php public/index.php -m batch -c cleanup --days=90  # 清理90天前的日志（默认30）
+ *   php public/index.php -m batch -c cleanup --dry-run  # 只统计，不实际删除
+ *
+ * crontab 示例（每天凌晨3点自动执行）:
+ *   0 3 * * * php /var/www/public/index.php -m batch -c cleanup --days=30
+ */
+class batch_cleanup_cmd extends batch_base_cmd
+{
+    public function run(array $opts): void
+    {
+        $days   = max(7, (int)($opts['days'] ?? 30));
+        $dryRun = isset($opts['dry-run']) || isset($opts['dry_run']);
+        $before = date('Y-m-d H:i:s', strtotime("-{$days} days"));
+
+        $this->log($dryRun ? "[DRY-RUN] 模拟清理，不会实际删除数据" : "开始清理 {$days} 天前数据（早于 {$before}）");
+
+        $db = DB();
+
+        // 1. 清理被删文章下的孤儿评论
+        $orphanCount = $db->count('blog_comments', [
+            'post_id' => $db->select('blog_posts', 'id', ['status' => -1]),
+        ]);
+        $this->log("孤儿评论（已删文章的评论）: {$orphanCount} 条");
+        if (!$dryRun && $orphanCount > 0) {
+            $db->delete('blog_comments', [
+                'post_id' => $db->select('blog_posts', 'id', ['status' => -1]),
+            ]);
+            $this->log("孤儿评论删除完成");
+        }
+
+        // 2. 清理 N 天前的旧日志文件
+        $logDir  = LOG_PATH;
+        $cleaned = 0;
+        foreach (glob($logDir . DS . '*.log*') as $file) {
+            if (filemtime($file) < strtotime("-{$days} days")) {
+                $this->log("日志文件: " . basename($file));
+                if (!$dryRun) {
+                    unlink($file);
+                }
+                $cleaned++;
+            }
+        }
+        $this->log($dryRun ? "可清理日志文件: {$cleaned} 个" : "日志文件清理完成: {$cleaned} 个");
+
+        // 3. 清理长期未登录的禁用账号（超过 N 天未登录 + 状态为禁用）
+        $staleCount = $db->count('users', [
+            'status'            => 0,
+            'last_login_at[<]'  => $before,
+        ]);
+        $this->log("长期禁用账号: {$staleCount} 条");
+        if (!$dryRun && $staleCount > 0) {
+            $db->update('users', ['status' => -1], [
+                'status'           => 0,
+                'last_login_at[<]' => $before,
+            ]);
+            $this->log("已将 {$staleCount} 个长期禁用账号标记为已删除");
+        }
+
+        L("数据清理完成: orphan={$orphanCount} logs={$cleaned} stale={$staleCount} dry={$dryRun}", [], 'INFO');
+        $this->log($dryRun ? '[DRY-RUN] 模拟结束，未做任何修改' : '清理完成！');
+    }
+}

--- a/application/batch/console/report.cmd.php
+++ b/application/batch/console/report.cmd.php
@@ -1,0 +1,122 @@
+<?php
+
+/**
+ * 周报导出命令 —— 适合配合 crontab 自动执行
+ *
+ * 用法:
+ *   php public/index.php -m batch -c report
+ *   php public/index.php -m batch -c report --days=30    # 近30天（默认7）
+ *   php public/index.php -m batch -c report --output=csv # 输出到 CSV 文件
+ *
+ * crontab 示例（每周一00:05执行）:
+ *   5 0 * * 1 php /var/www/public/index.php -m batch -c report >> /var/log/plume/report.log 2>&1
+ */
+class batch_report_cmd extends batch_base_cmd
+{
+    public function run(array $opts): void
+    {
+        $days   = max(1, (int)($opts['days'] ?? 7));
+        $output = $opts['output'] ?? 'console';
+        $since  = date('Y-m-d 00:00:00', strtotime("-{$days} days"));
+
+        $this->log("生成近 {$days} 天报表（自 {$since}）");
+
+        $db = DB();
+
+        // 新增用户
+        $newUsers = $db->count('users', ['created_at[>=]' => $since]);
+
+        // 活跃用户（近期有登录记录）
+        $activeUsers = $db->count('users', [
+            'last_login_at[>=]' => $since,
+            'status'            => 1,
+        ]);
+
+        // 发布文章
+        $newPosts = $db->count('blog_posts', [
+            'created_at[>=]' => $since,
+            'status'         => 1,
+        ]);
+
+        // 评论数
+        $newComments = $db->count('blog_comments', ['created_at[>=]' => $since]);
+
+        // 每日明细
+        $dailyDetail = $db->query(
+            "SELECT
+               DATE(created_at)              AS day,
+               COUNT(*)                      AS new_users,
+               SUM(last_login_at >= :since)  AS active
+             FROM users
+             WHERE created_at >= :since2
+             GROUP BY DATE(created_at)
+             ORDER BY day ASC",
+            [':since' => $since, ':since2' => $since]
+        )->fetchAll(\PDO::FETCH_ASSOC);
+
+        // 阅读量 Top5 文章
+        $topPosts = $db->select('blog_posts', ['id', 'title', 'view_count', 'author_name'], [
+            'status' => 1,
+            'ORDER'  => ['view_count' => 'DESC'],
+            'LIMIT'  => 5,
+        ]);
+
+        if ($output === 'csv') {
+            $this->saveAsCsv($days, $dailyDetail, $topPosts);
+        } else {
+            $this->printReport($days, $newUsers, $activeUsers, $newPosts, $newComments, $dailyDetail, $topPosts);
+        }
+    }
+
+    private function printReport(
+        int $days,
+        int $newUsers,
+        int $activeUsers,
+        int $newPosts,
+        int $newComments,
+        array $daily,
+        array $topPosts
+    ): void {
+        echo PHP_EOL;
+        echo "========== 近 {$days} 天数据报表 ==========\n";
+        echo "新增用户:   {$newUsers}\n";
+        echo "活跃用户:   {$activeUsers}\n";
+        echo "新增文章:   {$newPosts}\n";
+        echo "新增评论:   {$newComments}\n";
+
+        echo "\n--- 每日明细 ---\n";
+        printf("%-12s %-10s %-10s\n", '日期', '新增用户', '活跃用户');
+        foreach ($daily as $row) {
+            printf("%-12s %-10d %-10d\n", $row['day'], $row['new_users'], $row['active']);
+        }
+
+        echo "\n--- 阅读量 Top5 ---\n";
+        foreach ($topPosts as $i => $post) {
+            printf("%d. [%5d 次] %s (%s)\n", $i + 1, $post['view_count'], $post['title'], $post['author_name']);
+        }
+        echo "==========================================\n";
+    }
+
+    private function saveAsCsv(int $days, array $daily, array $topPosts): void
+    {
+        $filename = 'report_' . date('Ymd') . "_{$days}d.csv";
+        $path     = LOG_PATH . DS . $filename;
+
+        $fp = fopen($path, 'w');
+        fputs($fp, "\xEF\xBB\xBF");   // UTF-8 BOM，Excel 兼容
+
+        fputcsv($fp, ['日期', '新增用户', '活跃用户']);
+        foreach ($daily as $row) {
+            fputcsv($fp, [$row['day'], $row['new_users'], $row['active']]);
+        }
+
+        fputcsv($fp, []);
+        fputcsv($fp, ['排名', '文章标题', '作者', '阅读量']);
+        foreach ($topPosts as $i => $post) {
+            fputcsv($fp, [$i + 1, $post['title'], $post['author_name'], $post['view_count']]);
+        }
+
+        fclose($fp);
+        $this->log("CSV 已保存: {$path}");
+    }
+}

--- a/application/batch/console/seed.cmd.php
+++ b/application/batch/console/seed.cmd.php
@@ -1,0 +1,88 @@
+<?php
+
+/**
+ * 数据库播种命令 —— 用于开发环境快速初始化演示数据
+ *
+ * 用法:
+ *   php public/index.php -m batch -c seed
+ *   php public/index.php -m batch -c seed --truncate   # 先清空再插入
+ *   php public/index.php -m batch -c seed --count=50   # 指定生成条数
+ */
+class batch_seed_cmd extends batch_base_cmd
+{
+    public function run(array $opts): void
+    {
+        $truncate = isset($opts['truncate']);
+        $count    = max(1, (int)($opts['count'] ?? 20));
+
+        if ($truncate && !$this->confirm("将清空 users/blog_posts 表，确认？")) {
+            $this->log('已取消', 'WARN');
+            return;
+        }
+
+        $db = DB();
+
+        if ($truncate) {
+            $db->query('TRUNCATE TABLE blog_comments');
+            $db->query('TRUNCATE TABLE blog_posts');
+            $db->query('TRUNCATE TABLE users');
+            $this->log('表已清空');
+        }
+
+        // 生成用户
+        $this->log("开始生成 {$count} 个用户...");
+        $userIds = [];
+        for ($i = 1; $i <= $count; $i++) {
+            $uid = $db->insert('users', [
+                'username'   => 'user_' . generate_nonce_str(6),
+                'email'      => 'user' . $i . '_' . generate_nonce_str(4) . '@example.com',
+                'password'   => password_hash('password123', PASSWORD_BCRYPT),
+                'status'     => 1,
+                'created_at' => date('Y-m-d H:i:s', time() - rand(0, 86400 * 30)),
+            ]);
+            $userIds[] = $uid;
+        }
+        $this->log("用户生成完成: " . count($userIds) . " 条");
+
+        // 生成博客文章
+        $this->log("开始生成 {$count} 篇博客文章...");
+        $postIds = [];
+        $topics  = ['PHP开发', 'MySQL优化', 'Linux运维', 'Nginx配置', '设计模式', '前端实践'];
+        foreach ($userIds as $uid) {
+            $topic  = $topics[array_rand($topics)];
+            $title  = "{$topic}：第" . rand(1, 100) . "篇实战笔记";
+            $postId = $db->insert('blog_posts', [
+                'title'       => $title,
+                'content'     => "这是关于 {$topic} 的一篇详细文章，内容充实，涵盖了从基础到进阶的各个方面...\n\n" . str_repeat("示例段落内容。", rand(3, 10)),
+                'summary'     => "一篇关于 {$topic} 的实战笔记",
+                'author_id'   => $uid,
+                'author_name' => 'user_' . $uid,
+                'status'      => 1,
+                'view_count'  => rand(0, 5000),
+                'created_at'  => date('Y-m-d H:i:s', time() - rand(0, 86400 * 60)),
+            ]);
+            $postIds[] = $postId;
+        }
+        $this->log("文章生成完成: " . count($postIds) . " 条");
+
+        // 生成评论
+        $this->log("开始生成评论...");
+        $commentCount = 0;
+        foreach ($postIds as $postId) {
+            $n = rand(0, 5);
+            for ($j = 0; $j < $n; $j++) {
+                $db->insert('blog_comments', [
+                    'post_id'     => $postId,
+                    'author_name' => '访客' . generate_nonce_str(4),
+                    'content'     => '写得不错，学到了！' . generate_nonce_str(8),
+                    'ip'          => rand(1, 255) . '.' . rand(0, 255) . '.0.1',
+                    'created_at'  => date('Y-m-d H:i:s', time() - rand(0, 86400 * 30)),
+                ]);
+                $commentCount++;
+            }
+        }
+        $this->log("评论生成完成: {$commentCount} 条");
+
+        $this->log('全部播种完成！');
+    }
+}

--- a/application/blog/actions/comment.action.php
+++ b/application/blog/actions/comment.action.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * 评论提交（JSON API，AJAX Only）
+ * POST /blog/comment
+ */
+class blog_comment_action extends blog_base_action
+{
+    protected array $rules = [
+        'post_id'     => 'required|int|min:1',
+        'author_name' => 'required|string|minLen:2|maxLen:30',
+        'content'     => 'required|string|minLen:5|maxLen:1000',
+    ];
+
+    public function invoke()
+    {
+        if (!IS_POST) {
+            $this->error('Method Not Allowed', 405, true);
+        }
+
+        $postId     = (int) $this->getParam('post_id');
+        $authorName = html_filter($this->getParam('author_name', ''));
+        $content    = html_filter($this->getParam('content', ''));
+
+        $db   = DB();
+        $post = $db->get('blog_posts', ['id'], ['id' => $postId, 'status' => 1]);
+        if (!$post) {
+            $this->error('文章不存在', 404, true);
+        }
+
+        $id = $db->insert('blog_comments', [
+            'post_id'     => $postId,
+            'author_name' => $authorName,
+            'content'     => $content,
+            'ip'          => get_client_ip(),
+            'created_at'  => date('Y-m-d H:i:s'),
+        ]);
+
+        $this->correct([
+            'id'         => $id,
+            'author'     => $authorName,
+            'content'    => $content,
+            'created_at' => date('Y-m-d H:i:s'),
+        ], '评论成功');
+    }
+}

--- a/application/blog/actions/post.action.php
+++ b/application/blog/actions/post.action.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * 文章列表 & 详情
+ * GET /blog/post          → 列表（带分页）
+ * GET /blog/post?id=1     → 文章详情
+ */
+class blog_post_action extends blog_base_action
+{
+    protected $csrfValidate = false;
+
+    public function invoke()
+    {
+        $id = (int) $this->getParam('id', 0);
+
+        if ($id > 0) {
+            $this->showDetail($id);
+        } else {
+            $this->showList();
+        }
+    }
+
+    private function showList(): void
+    {
+        $page    = max(1, (int) $this->getParam('page', 1));
+        $perPage = 10;
+        $offset  = ($page - 1) * $perPage;
+
+        $db    = DB();
+        $total = $db->count('blog_posts', ['status' => 1]);
+        $posts = $db->select('blog_posts', [
+            'id', 'title', 'summary', 'author_name', 'created_at', 'view_count',
+        ], [
+            'status'  => 1,
+            'ORDER'   => ['created_at' => 'DESC'],
+            'LIMIT'   => [$offset, $perPage],
+        ]);
+
+        $this->assign('posts',     $posts ?: []);
+        $this->assign('page',      $page);
+        $this->assign('totalPage', (int) ceil($total / $perPage));
+        $this->render('post/list', 'layout');
+    }
+
+    private function showDetail(int $id): void
+    {
+        $db   = DB();
+        $post = $db->get('blog_posts', '*', ['id' => $id, 'status' => 1]);
+
+        if (!$post) {
+            $this->error('文章不存在', 404);
+        }
+
+        // 异步更新浏览量（不影响响应速度）
+        $db->update('blog_posts', ['view_count[+]' => 1], ['id' => $id]);
+
+        $comments = $db->select('blog_comments', [
+            'id', 'author_name', 'content', 'created_at',
+        ], [
+            'post_id' => $id,
+            'ORDER'   => ['created_at' => 'ASC'],
+            'LIMIT'   => 50,
+        ]);
+
+        $this->assign('post',     $post);
+        $this->assign('comments', $comments ?: []);
+        $this->render('post/detail', 'layout');
+    }
+}

--- a/application/blog/actions/post/create.action.php
+++ b/application/blog/actions/post/create.action.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * 新建文章
+ * GET  /blog/post/create  → 显示表单
+ * POST /blog/post/create  → 保存
+ */
+class blog_post_create_action extends blog_base_action
+{
+    protected $requireLogin = true;
+
+    // 声明式参数验证 —— 框架在 invoke() 前自动执行
+    protected array $rules = [
+        'title'   => 'required|string|minLen:4|maxLen:200',
+        'content' => 'required|string|minLen:10',
+        'summary' => 'string|maxLen:500',
+    ];
+
+    public function invoke()
+    {
+        if (IS_POST) {
+            $this->save();
+        } else {
+            $this->render('post/create', 'layout');
+        }
+    }
+
+    private function save(): void
+    {
+        $user    = $this->currentUser();
+        $title   = html_filter($this->getParam('title', ''));
+        $content = html_filter($this->getParam('content', ''));
+        $summary = html_filter($this->getParam('summary', ''));
+
+        $db = DB();
+        $id = $db->insert('blog_posts', [
+            'title'       => $title,
+            'content'     => $content,
+            'summary'     => $summary ?: strcut(strip_tags($content), 150, '...'),
+            'author_id'   => $user['id'],
+            'author_name' => $user['name'],
+            'status'      => 1,
+            'view_count'  => 0,
+            'created_at'  => date('Y-m-d H:i:s'),
+        ]);
+
+        L("新文章发布: id={$id} title={$title}", ['user_id' => $user['id']], 'INFO');
+
+        redirect("/blog/post?id={$id}");
+    }
+}

--- a/application/blog/blog.boot.php
+++ b/application/blog/blog.boot.php
@@ -1,0 +1,37 @@
+<?php
+
+PlumePHP::app()->path(PLUME_PHP_PATH . DS . 'library' . DS . 'core');
+
+abstract class blog_base_action extends \Plume\Libs\Action
+{
+    protected $csrfValidate = true;
+    protected $requireLogin = false;
+
+    public function init()
+    {
+        if ($this->requireLogin && empty($_SESSION['user_id'])) {
+            if (IS_AJAX) {
+                $this->error('请先登录', 401, true);
+            }
+            redirect('/blog/auth/login');
+        }
+        return true;
+    }
+
+    public function execute()
+    {
+        if ($this->init()) {
+            return $this->invoke();
+        }
+    }
+
+    abstract public function invoke();
+
+    protected function currentUser(): array
+    {
+        return [
+            'id'   => $_SESSION['user_id'] ?? 0,
+            'name' => $_SESSION['user_name'] ?? '',
+        ];
+    }
+}

--- a/application/blog/views/layout.tpl.php
+++ b/application/blog/views/layout.tpl.php
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>PlumePHP 博客</title>
+<link rel="stylesheet" href="/static/blog.css">
+</head>
+<body>
+<nav class="navbar">
+  <a href="/blog/post" class="brand">PlumePHP Blog</a>
+  <a href="/blog/post/create" class="btn-new">写文章</a>
+</nav>
+<main class="container">
+  <?php echo $__content__; ?>
+</main>
+<footer><p>Powered by PlumePHP</p></footer>
+<?php foreach ($js_files as $js): ?>
+<script src="<?= htmlspecialchars($js) ?>"></script>
+<?php endforeach; ?>
+</body>
+</html>

--- a/application/blog/views/post/create.tpl.php
+++ b/application/blog/views/post/create.tpl.php
@@ -1,0 +1,20 @@
+<div class="editor-page">
+  <h1>写新文章</h1>
+  <form method="POST" action="/blog/post/create">
+    <?= $csrfField ?? '' ?>
+    <div class="field">
+      <label>标题</label>
+      <input name="title" maxlength="200" placeholder="给文章起个好标题" required>
+    </div>
+    <div class="field">
+      <label>摘要（可选，留空自动截取）</label>
+      <input name="summary" maxlength="500" placeholder="一句话描述文章内容">
+    </div>
+    <div class="field">
+      <label>正文</label>
+      <textarea name="content" rows="20" placeholder="开始写作..." required></textarea>
+    </div>
+    <button type="submit" class="btn-primary">发布文章</button>
+    <a href="/blog/post" class="btn-cancel">取消</a>
+  </form>
+</div>

--- a/application/blog/views/post/detail.tpl.php
+++ b/application/blog/views/post/detail.tpl.php
@@ -1,0 +1,43 @@
+<article class="post-full">
+  <h1><?= htmlspecialchars($post['title']) ?></h1>
+  <p class="meta">
+    <?= htmlspecialchars($post['author_name']) ?>
+    &middot; <?= human_date($post['created_at']) ?>
+    &middot; <?= (int)$post['view_count'] ?> 阅读
+  </p>
+  <div class="content"><?= $post['content'] ?></div>
+</article>
+
+<section class="comments">
+  <h3>评论（<?= count($comments) ?>）</h3>
+
+  <?php foreach ($comments as $c): ?>
+  <div class="comment">
+    <strong><?= htmlspecialchars($c['author_name']) ?></strong>
+    <span class="time"><?= human_date($c['created_at']) ?></span>
+    <p><?= htmlspecialchars($c['content']) ?></p>
+  </div>
+  <?php endforeach; ?>
+
+  <form id="comment-form" class="comment-form">
+    <?= $csrfField ?? '' ?>
+    <input type="hidden" name="post_id" value="<?= (int)$post['id'] ?>">
+    <input name="author_name" placeholder="您的昵称" required>
+    <textarea name="content" rows="4" placeholder="说点什么..." required></textarea>
+    <button type="submit">发布评论</button>
+  </form>
+</section>
+
+<script>
+document.getElementById('comment-form').addEventListener('submit', async function(e) {
+  e.preventDefault();
+  const form = new FormData(this);
+  const res  = await fetch('/blog/comment', { method: 'POST', body: form });
+  const json = await res.json();
+  if (json.code === 0) {
+    location.reload();
+  } else {
+    alert(json.msg);
+  }
+});
+</script>

--- a/application/blog/views/post/list.tpl.php
+++ b/application/blog/views/post/list.tpl.php
@@ -1,0 +1,29 @@
+<div class="post-list">
+  <h1>最新文章</h1>
+
+  <?php if (empty($posts)): ?>
+    <p class="empty">还没有文章，<a href="/blog/post/create">来写第一篇吧</a></p>
+  <?php else: ?>
+    <?php foreach ($posts as $post): ?>
+    <article class="post-card">
+      <h2><a href="/blog/post?id=<?= $post['id'] ?>"><?= htmlspecialchars($post['title']) ?></a></h2>
+      <p class="meta">
+        <?= htmlspecialchars($post['author_name']) ?>
+        &middot; <?= human_date($post['created_at']) ?>
+        &middot; <?= (int)$post['view_count'] ?> 阅读
+      </p>
+      <p class="summary"><?= htmlspecialchars($post['summary']) ?></p>
+    </article>
+    <?php endforeach; ?>
+
+    <nav class="pagination">
+      <?php if ($page > 1): ?>
+        <a href="?page=<?= $page - 1 ?>">上一页</a>
+      <?php endif; ?>
+      <span>第 <?= $page ?> / <?= $totalPage ?> 页</span>
+      <?php if ($page < $totalPage): ?>
+        <a href="?page=<?= $page + 1 ?>">下一页</a>
+      <?php endif; ?>
+    </nav>
+  <?php endif; ?>
+</div>

--- a/scripts/schema.sql
+++ b/scripts/schema.sql
@@ -1,0 +1,62 @@
+-- PlumePHP 示例场景建表脚本
+-- 执行: mysql -u root -p your_db < scripts/schema.sql
+
+CREATE TABLE IF NOT EXISTS `users` (
+  `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `username`      VARCHAR(30)  NOT NULL UNIQUE,
+  `email`         VARCHAR(120) NOT NULL UNIQUE,
+  `password`      VARCHAR(255) NOT NULL,
+  `status`        TINYINT      NOT NULL DEFAULT 1 COMMENT '1正常 0禁用 -1已删除',
+  `created_at`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `last_login_at` DATETIME     NULL,
+  INDEX idx_status (`status`),
+  INDEX idx_created (`created_at`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='用户表';
+
+CREATE TABLE IF NOT EXISTS `admins` (
+  `id`            INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `username`      VARCHAR(30)  NOT NULL UNIQUE,
+  `password`      VARCHAR(255) NOT NULL,
+  `role`          VARCHAR(30)  NOT NULL DEFAULT 'admin',
+  `last_login_at` DATETIME     NULL,
+  `created_at`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='管理员表';
+
+CREATE TABLE IF NOT EXISTS `blog_posts` (
+  `id`          INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `title`       VARCHAR(200) NOT NULL,
+  `summary`     VARCHAR(500) NOT NULL DEFAULT '',
+  `content`     MEDIUMTEXT   NOT NULL,
+  `author_id`   INT UNSIGNED NOT NULL,
+  `author_name` VARCHAR(30)  NOT NULL,
+  `status`      TINYINT      NOT NULL DEFAULT 1 COMMENT '1已发布 0草稿 -1已删除',
+  `view_count`  INT UNSIGNED NOT NULL DEFAULT 0,
+  `created_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_status_created (`status`, `created_at`),
+  INDEX idx_author (`author_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='博客文章';
+
+CREATE TABLE IF NOT EXISTS `blog_comments` (
+  `id`          INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `post_id`     INT UNSIGNED NOT NULL,
+  `author_name` VARCHAR(30)  NOT NULL,
+  `content`     TEXT         NOT NULL,
+  `ip`          VARCHAR(45)  NOT NULL DEFAULT '',
+  `created_at`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_post (`post_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='文章评论';
+
+CREATE TABLE IF NOT EXISTS `articles` (
+  `id`         INT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  `title`      VARCHAR(200) NOT NULL,
+  `content`    MEDIUMTEXT   NOT NULL,
+  `author_id`  INT UNSIGNED NOT NULL,
+  `status`     TINYINT      NOT NULL DEFAULT 1,
+  `created_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  `updated_at` DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  INDEX idx_author (`author_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COMMENT='API文章资源';
+
+-- 初始管理员账号（密码: admin123）
+INSERT IGNORE INTO `admins` (`username`, `password`, `role`) VALUES
+('admin', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'admin');


### PR DESCRIPTION
## 概述

新增四个完整的真实使用场景，展示 PlumePHP 框架的实际价值，覆盖 Web 应用、REST API、后台管理、CLI 批处理四个典型场景。

---

## 场景1：博客系统 (`application/blog/`)

展示框架的 **MVC + 模板 + CSRF + 声明式验证** 全流程。

| 文件 | 说明 |
|---|---|
| `blog.boot.php` | 模块基类，含 `requireLogin` 会话守卫 |
| `actions/post.action.php` | 文章列表（分页）+ 详情（自动统计阅读量） |
| `actions/post/create.action.php` | 新建文章，`$rules` 声明式验证 + `html_filter` 防 XSS |
| `actions/comment.action.php` | 评论提交 JSON API，CSRF + 参数验证 |
| `views/post/*.tpl.php` | 原生 PHP 模板，含 AJAX 评论提交逻辑 |

**亮点**：`$rules` 字段验证在 `invoke()` 前自动执行，无需手写 if 判断；`human_date()` / `html_filter()` / `strcut()` 等助手函数开箱即用。

---

## 场景2：REST API + Token 鉴权 (`application/api/`)

展示框架的 **Bearer Token 鉴权 + 纯 JSON 响应 + CRUD** 模式。

| 文件 | 说明 |
|---|---|
| `api.boot.php` | Token 解析中间件（`authcode` 加密，自动 401） |
| `actions/user.action.php` | 注册（含唯一性检查）、登录、个人信息 |
| `actions/article.action.php` | 文章资源完整 CRUD，分页列表，所有权校验 |

**亮点**：利用 `authcode()` 实现无状态 Token，无需引入 JWT 库；`correct()` / `error()` 统一 JSON 信封格式 `{code, msg, data}`。

---

## 场景3：后台管理面板 (`application/admin/`)

展示框架的 **会话鉴权中间件 + 多表统计 + CSV 导出** 能力。

| 文件 | 说明 |
|---|---|
| `admin.boot.php` | 管理员会话守卫 + 角色检查 |
| `actions/auth.action.php` | 登录/登出，`password_verify` 校验 |
| `actions/dashboard.action.php` | 数据看板：多项计数统计 + 近7天趋势原生 SQL |
| `actions/user.action.php` | 用户列表（关键字搜索/分页）+ 状态切换 + CSV 一键导出 |

**亮点**：`export_csv()` 助手函数一行完成 CSV 下载；`IS_AJAX` 常量自动区分页面错误和 JSON 错误响应。

---

## 场景4：CLI 批处理工具 (`application/batch/`)

展示框架的 **CLI 命令系统** 适用于定时任务场景。

| 命令 | 用法 | 说明 |
|---|---|---|
| `seed` | `php public/index.php -m batch -c seed --count=50` | 生成演示数据，支持 `--truncate` 先清空 |
| `report` | `php public/index.php -m batch -c report --days=7 --output=csv` | 周报导出（控制台 / CSV 文件），适合 crontab |
| `cleanup` | `php public/index.php -m batch -c cleanup --dry-run` | 过期数据清理，支持 `--dry-run` 预览 |

**亮点**：CLI 命令与 Web Action 共用同一套框架基础设施（`DB()`、`L()`、`C()`、`generate_nonce_str()` 等），无需维护独立脚本环境。

---

## 数据库初始化

`scripts/schema.sql` 包含所有示例表的建表语句及初始管理员账号，执行即可本地运行：

```bash
mysql -u root -p your_db < scripts/schema.sql
php public/index.php -m batch -c seed --count=20
php -S localhost:8000 -t public/
```

## Test plan

- [ ] `scripts/schema.sql` 可在 MySQL 8.x 执行无报错
- [ ] `GET /blog/post` 返回文章列表页
- [ ] `POST /blog/post/create` 在未登录时重定向到登录页
- [ ] `POST /api/user/register` 返回 `{code:0, data:{token:...}}`
- [ ] `GET /api/article` 未带 Token 返回 `{code:401}`
- [ ] `GET /admin/dashboard` 未登录重定向 `/admin/auth/login`
- [ ] `php public/index.php -m batch -c seed --dry-run` 不报错（注：seed 无 dry-run，cleanup 有）
- [ ] `php public/index.php -m batch -c report` 输出表格

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014DnMcNKrUAbvAUFETZ264j

---
_Generated by [Claude Code](https://claude.ai/code/session_014DnMcNKrUAbvAUFETZ264j)_