### PR TITLE
docs: 全面重写 README.md，与当前代码库保持一致

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,96 +1,553 @@
-PlumePHP - 羽量级的单文件php开发框架
+# PlumePHP — 羽量级的单文件 PHP 开发框架
 
-## 快速启动（无需 PHP-FPM / Nginx）
+> PHP >= 8.1 · PSR-3 日志 · PSR-11 容器 · PSR-15 中间件 · Apache-2.0
 
-PlumePHP 可直接使用 PHP 内置 Web Server 运行，无需配置任何 Web 服务器，适合本地研发和测试。
+---
+
+## 快速启动
 
 ```bash
-# 标准启动（推荐）
+# 内置 Web Server（开发/测试用，单进程）
 php -S localhost:8000 -t public/ public/index.php
 
-# 指定 testing 环境（关闭 display_errors，保留错误报告）
+# 指定环境变量
 PLUME_PHP_ENV=testing php -S localhost:8000 -t public/ public/index.php
 
-# 通过框架 CLI 启动（等效于上面，已内置端口占用检测）
+# 通过框架 CLI 启动（内置端口占用检测）
 php public/index.php -S
 php public/index.php -S -H 0.0.0.0 -P 9000   # 自定义地址端口
 php public/index.php -S -b                     # 后台运行
 
-# 运行 CLI 命令（脚本/定时任务模式）
+# 运行 CLI 命令
 php public/index.php -m web -c migrate
 ```
 
-> **注意**：PHP 内置 Server 是单进程的，一次只处理一个请求，仅用于开发测试，不适合生产环境。
+> PHP 内置 Server 是单进程的，一次只处理一个请求，仅用于开发测试，不适合生产环境。
 
 ---
 
-### 简介
+## 简介
 
-PlumePHP是一个单入口，单文件PHP框架，适用于简单系统的快速开发，提供了简单的路由方式，抛弃了坑爹的PHP模板，采用原生PHP语法来渲染页面。如果您正在开发一个简单的功能，而又不想使用Yii，CodeIgniter，ThinkPHP等框架，则可以试用一下该框架。
+PlumePHP 是一个单入口、极简 PHP 框架，适合快速构建中小型系统。提供路由、模板、日志、数据库、CSRF、中间件等开箱即用的能力，同时支持 FrankenPHP Worker 常驻内存模式。
 
-区别于其他Web框架，该框架是一个绝对的单文件框架（整个框架只有一个index.php文件，与PHP入口文件index.php相同），不需要额外的引用或配置。
+---
 
-使用方法也及其简单，只需下载框架文件index.php到项目根目录，然后通过浏览器输入项目访问地址，即可自动生成框架目录结构（项目目录需要有写入权限）。
+## 入口文件
 
-### 特点
-
-- 加载简单，引入只需一个文件
-- 日志机制
-- 支持HTTP（网页模式）和cli（脚本模式）两种模式
-- 事件驱动
-- 数据库操作简便
-- 助手类引入便捷
-- 文件处理封装
-- 时间处理封装
-- Socket请求封装，支持代理模式
-- Session支持cookie、file、db多种方式
-- 支持委托代理机制
-- 安全过滤器机制
-- 其他
-
-## 入口文件：index.php
+推荐使用静态门面写法——无需捕获 `$app` 变量即可在闭包中使用，且能正确触发 before/after 过滤器链：
 
 ```php
-// 加载框架文件
+// public/index.php
+include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'PlumePHP.php';
+
+PlumePHP::route('GET /api', function () {
+    echo json_encode(['code' => 0, 'data' => 'api', 'msg' => 'success'], JSON_UNESCAPED_UNICODE);
+});
+
+PlumePHP::route('GET /', function () {
+    echo 'Hello World!';
+});
+
+// 通用路由：按 /{module}/{controller}/{action} 解析文件
+PlumePHP::route('*', function () {
+    PlumePHP::app()->runAction();
+});
+
+PlumePHP::start();
+```
+
+也可以使用 `$app` 实例风格（与上面等价，差异见下文）：
+
+```php
 include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'PlumePHP.php';
 
 $app = PlumePHP::app();
 
-// api首页展示
-$app->route('GET /api', function() {
-    echo json_encode(['code'=>0, 'data'=>'api', 'msg'=>'success'], JSON_UNESCAPED_UNICODE);
+$app->route('GET /api', function () {
+    echo json_encode(['code' => 0, 'data' => 'api', 'msg' => 'success'], JSON_UNESCAPED_UNICODE);
 });
 
-$app->route('GET /', function () {
-    echo 'Hello World!';
-    return false;
+$app->route('*', function () use ($app) {
+    $app->runAction();
 });
 
-// 通用的路由逻辑
-$app->route('*', function() use ($app) {
-   $app->runAction();
-});
-
-// 启动
 $app->start();
 ```
 
-or 
+**两种写法的区别：**`PlumePHP::method()` 通过 `__callStatic` 转发，会检查并触发 `before/after` 过滤器；`$app->method()` 直接调用，绕过事件系统。如未使用事件过滤器，两者行为完全一致。
+
+---
+
+## 路由
 
 ```php
-// 加载框架文件
-include dirname(__DIR__) . DIRECTORY_SEPARATOR . 'PlumePHP.php';
+// 方法限定
+PlumePHP::route('GET /search', $callback);
+PlumePHP::route('GET|POST /form', $callback);
 
-// api首页展示
-PlumePHP::route('GET /api', function() {
-    echo json_encode(['code'=>0, 'data'=>'api', 'msg'=>'success'], JSON_UNESCAPED_UNICODE);
-});
+// 命名参数
+PlumePHP::route('/user/@id', function ($id) { ... });
 
-// 通用的路由逻辑
-PlumePHP::route('*', function() {
-    PlumePHP::app()->runAction();
-});
+// 参数 + 正则约束
+PlumePHP::route('/post/@slug:[a-z-]+', function ($slug) { ... });
 
-// 启动
+// 可选段
+PlumePHP::route('/blog(/@year(/@month))', function ($y, $m) { ... });
+
+// 通配符（splat）
+PlumePHP::route('/files/*', function ($splat) { ... });
+
+// 捕获路由对象（第三个参数为 true）
+PlumePHP::route('/info', $callback, true);   // 回调最后一个参数为 PlumeRoute
+
+// 路由组（共享前缀 + 可选中间件）
+PlumePHP::group('/api', function () {
+    PlumePHP::route('/users', $callback);
+    PlumePHP::route('/orders', $callback);
+}, [$middleware]);
+
+// 捕获所有（catch-all）
+PlumePHP::route('*', $callback);
+```
+
+- 按声明顺序匹配，第一个匹配的路由生效
+- 回调返回 `true` 则继续匹配下一条路由
+- 默认大小写不敏感；`PlumePHP::router()->case_sensitive = true` 开启敏感模式
+
+### 路由正则缓存
+
+路由较多时可开启编译缓存，避免每次请求重复解析正则：
+
+```php
+PlumePHP::app()->enableRouteCache('/path/to/storage/route_cache.php');
+// 或
+PlumePHP::router()->enableCache('/path/to/storage/route_cache.php');
+```
+
+---
+
+## 中间件（PSR-15）
+
+```php
+class AuthMiddleware implements PlumeMiddlewareInterface
+{
+    public function process(PlumeRequest $request, PlumeRequestHandlerInterface $handler): PlumeResponse
+    {
+        if (!isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            return PlumePHP::response()->status(401)->write('Unauthorized');
+        }
+        return $handler->handle($request);
+    }
+}
+
+PlumePHP::app()->addMiddleware(new AuthMiddleware());
 PlumePHP::start();
+```
+
+---
+
+## 请求与响应
+
+```php
+$req = PlumePHP::request();
+$req->query['id'];          // $_GET
+$req->data['name'];         // $_POST
+$req->method;               // GET / POST / PUT …
+$req->url;                  // 当前 URL
+$req->headers['User-Agent'];
+
+$res = PlumePHP::response();
+$res->status(201)
+    ->header('X-Custom', 'value')
+    ->write('body')
+    ->send();
+
+// 快捷 JSON 响应
+PlumePHP::json(['code' => 0, 'data' => $data]);
+PlumePHP::jsonp(['code' => 0], 'callback');
+```
+
+---
+
+## 模板渲染
+
+```php
+// 渲染 views/home.tpl.php，使用 views/layout.tpl.php 包裹
+PlumePHP::render('home', ['user' => $user], null, 'layout');
+
+// 在 Action 内部
+$this->assign('user', $user);
+$this->render('home', 'layout');   // 第二参数为布局文件名
+$this->render('home', '');         // 不使用布局
+```
+
+模板文件位于 `views/`，扩展名默认 `.tpl.php`，变量通过 `extract()` 展开后直接可用。
+
+---
+
+## 日志
+
+```php
+L('message');                          // DEBUG，写入当日 .log
+L('warn', [], 'WARN', true);           // WARN，同时写入 .log.wf
+L('query', [], 'SQL');                 // SQL，写入 .log.sql
+
+// PSR-3 接口
+PlumePHP::logger()->info('started');
+PlumePHP::logger()->error('failed', ['code' => 500]);
+```
+
+**日志文件规则：**
+
+| 文件 | 级别 |
+|---|---|
+| `storage/log/YYYYMMDD.log` | DEBUG / INFO / NOTICE（同时写入 wf） |
+| `storage/log/YYYYMMDD.log.wf` | WARN / ERROR / FATAL / CRITICAL，以及 NOTICE |
+| `storage/log/YYYYMMDD.log.sql` | SQL |
+
+**输出格式（`setFormatter`）：**
+
+```php
+// text（默认）: [2025-01-01 12:00:00][logId][LEVEL]message
+// json: {"time":"...","log_id":"...","level":"...","msg":"...","ctx":{...}}
+PlumePHP::logger()->setFormatter('json');
+```
+
+**写入模式（`setMode`）：**
+
+```php
+// normal（默认）：每条日志立即落盘
+// batch：缓冲至请求结束统一落盘，减少 Worker 模式下的磁盘 I/O
+PlumePHP::logger()->setMode('batch');
+```
+
+**自定义 Handler（告警推送等）：**
+
+```php
+// 钉钉告警（ERROR 及以上级别触发）
+PlumePHP::logger()->addHandler(
+    PlumeLogHandlers::dingtalk('https://oapi.dingtalk.com/robot/send?access_token=xxx')
+);
+
+// Sentry
+PlumePHP::logger()->addHandler(
+    PlumeLogHandlers::sentry('https://key@sentry.io/project')
+);
+
+// 最低级别过滤器（包装任意 handler）
+PlumePHP::logger()->addHandler(
+    PlumeLogHandlers::minLevel('WARNING', PlumeLogHandlers::dingtalk($webhook))
+);
+```
+
+---
+
+## 配置
+
+```php
+// config/config.php 返回数组；PLUME_PHP_ENV 可选环境覆盖文件 config/{env}.php
+
+C('USE_SESSION')            // 读取顶层 key
+C('DB_CONF.master.db_port') // 点号最多三层
+C(['key1', 'key2'])         // 批量读取，返回关联数组
+C(['KEY' => 'val'])         // 批量写入
+
+C('MY_KEY', 'value');       // 单 key 写入
+
+// 引擎变量（运行时）
+PlumePHP::set('plumephp.base_url', 'https://example.com');
+PlumePHP::get('plumephp.base_url');
+PlumePHP::has('plumephp.base_url');
+PlumePHP::clear('plumephp.base_url');
+```
+
+**常用配置项：**
+
+| Key | 默认值 | 说明 |
+|---|---|---|
+| `USE_SESSION` | `true` | 自动启动 Session |
+| `TIME_ZONE` | `'Asia/Shanghai'` | 默认时区 |
+| `VDNAME` | `''` | 虚拟目录前缀 |
+| `DB_CONF` | `[...]` | 数据库连接配置 |
+| `plumephp.handle_errors` | `true` | 将 PHP 错误转为异常 |
+| `plumephp.case_sensitive` | `false` | 路由大小写敏感 |
+| `plumephp.base_url` | 自动 | 资源/链接基础 URL |
+| `plumephp.views.path` | `'./views'` | 模板目录 |
+| `plumephp.views.extension` | `'.tpl.php'` | 模板扩展名 |
+
+---
+
+## 扩展机制
+
+```php
+// 自定义方法
+PlumePHP::map('hello', function (string $name) {
+    echo "Hello, {$name}!";
+});
+PlumePHP::hello('World');
+
+// 注册懒加载服务
+PlumePHP::register('db', 'MyDB', [$dsn], function ($db) {
+    $db->connect();
+});
+PlumePHP::db();        // 共享实例
+PlumePHP::db(false);   // 每次返回新实例
+
+// Before / After 过滤器（before 返回 false 中断链）
+PlumePHP::before('start', function (&$params, &$output) { ... });
+PlumePHP::after('start',  function (&$params, &$output) { ... });
+```
+
+---
+
+## PSR-11 容器
+
+```php
+$container = PlumePHP::app()->container();
+
+// 绑定接口→实现
+$container->bind(LoggerInterface::class, MyLogger::class);
+
+// 绑定工厂
+$container->bindFactory('cache', function ($c) {
+    return new RedisCache($c->get('config'));
+});
+
+$logger = $container->get(LoggerInterface::class);
+```
+
+---
+
+## 数据库
+
+使用内置 **Medoo**（`library/core/Plume/Libs/Medoo.php`）：
+
+```php
+$db = DB();               // 默认连接（DB_CONF 第一条）
+$db = DB('master');       // 指定连接 key
+$db = DB(['db_server' => '127.0.0.1', 'db_name' => 'test', ...]);
+
+$rows  = $db->select('users', ['id', 'name'], ['age[>]' => 18]);
+$id    = $db->insert('users', ['name' => 'John', 'age' => 30]);
+$db->update('users', ['age' => 31], ['id' => 1]);
+$db->delete('users', ['id' => 1]);
+$rows  = $db->query('SELECT * FROM users')->fetchAll(\PDO::FETCH_ASSOC);
+```
+
+DB 配置字段：`db_server` / `db_port` / `db_user` / `db_password` / `db_name` / `db_charset` / `db_prefix`
+
+---
+
+## Module / Action 系统
+
+URL `/{module}/{controller}/{action}` 自动映射到文件系统：
+
+```
+application/
+  {module}/
+    {module}.boot.php          # 模块引导，定义基础 Action 类
+    actions/
+      {controller}.action.php  # class {module}_{controller}_action
+    console/
+      {cmd}.cmd.php            # class {module}_{cmd}_cmd（CLI）
+    views/
+      {template}.tpl.php
+      layout.tpl.php
+```
+
+**Action 示例：**
+
+```php
+// application/web/actions/home.action.php
+class web_home_action extends web_base_action
+{
+    // protected $csrfValidate = false;  // 关闭该 Action 的 CSRF 验证
+
+    public function invoke()
+    {
+        $id = $this->getParam('id', 0);
+
+        $this->assign('user', $userData);
+        $this->render('home', 'layout');    // 渲染模板
+
+        // 或返回 JSON
+        $this->correct(['key' => 'value']); // {code:0, msg:'', data:{...}}
+        $this->error('Not found', 404);     // {code:404, msg:'Not found'}
+    }
+
+    public function beforeRun()  { /* invoke() 前执行 */ }
+    public function afterRun($r) { /* invoke() 后执行 */ }
+}
+```
+
+**Action 常用方法：**
+
+| 方法 | 说明 |
+|---|---|
+| `getParam($name, $default)` | 获取 GET/POST/Cookie 参数 |
+| `setParam($name, $value)` | 设置请求参数 |
+| `assign($name, $value)` | 向模板传递变量 |
+| `render($view, $layout, $data)` | 渲染模板（自动注入 CSRF Token） |
+| `json($code, $msg, $data)` | 输出 `{code, msg, data}` JSON |
+| `correct($data, $msg)` | 等同 `json(0, $msg, $data)` |
+| `error($msg, $code, $asJson)` | 输出错误页或 JSON |
+| `getCsrfToken()` | 获取当前 CSRF Token |
+| `validateCsrfToken()` | 校验 Token（POST/PUT/PATCH 自动调用） |
+| `addJs($file)` / `addCss($file)` | 注册资源文件 |
+
+**CSRF 说明：**
+- Token 存储在 `plume-csrf-token` Cookie，验证对应 `plume-csrf` HMAC Cookie
+- 提交方式：`$_POST['plume_csrf']` 或 `X-CSRF-TOKEN` 请求头
+- 模板自动注入 `$csrf_token`（Token 值）和 `$csrf_field`（隐藏域 HTML）
+
+---
+
+## CLI 命令
+
+```php
+// application/web/console/migrate.cmd.php
+class web_migrate_cmd
+{
+    public function run(array $opts): void
+    {
+        // $opts = 解析后的 argv
+    }
+}
+```
+
+```bash
+php public/index.php -m web -c migrate
+php public/index.php --module web --cmd migrate --dry
+```
+
+---
+
+## Schema 与 JSON 映射
+
+`PlumeSchema` 是 JSON 可序列化的数据模型基类，属性名自动转为 snake_case：
+
+```php
+class UserSchema extends PlumeSchema
+{
+    public int $userId = 0;
+    public string $userName = '';
+}
+
+// 从请求参数创建
+$param  = PlumePHP::app()->request()->param();  // PlumeParam
+$user   = UserSchema::createFromPlumeParam($param);
+
+// 序列化为 JSON：{"user_id":1,"user_name":"John"}
+echo json_encode($user);
+```
+
+`PlumeJsonMapper` 独立使用时可将 JSON 数组映射到任意 PHP 对象：
+
+```php
+$mapper = new PlumeJsonMapper();
+$obj    = $mapper->map($jsonArray, new MyModel());
+```
+
+---
+
+## FrankenPHP Worker 模式
+
+Worker 模式下 PHP 常驻内存，每次请求复用进程，消除冷启动开销。入口为 `public/worker.php`：
+
+```php
+// 路由每次请求重新注册（resetForWorker 会清空路由）
+while (frankenphp_handle_request(function () {
+    PlumePHP::resetForWorker();   // 重置路由、请求/响应、Session，保留 boot 配置
+
+    PlumePHP::route('GET /api', fn() => ...);
+    PlumePHP::route('*', fn() => PlumePHP::app()->runAction());
+
+    PlumePHP::start();
+}));
+```
+
+```bash
+# 开发（传统模式）
+frankenphp php-server --root public/
+
+# Worker 模式
+frankenphp php-server --worker public/worker.php --root public/
+```
+
+> Worker 模式下，不要在静态变量或模块级单例中存储请求相关状态，它们在请求间持久存在。
+
+---
+
+## 全局辅助函数
+
+| 函数 | 说明 |
+|---|---|
+| `C($key, $val)` | 配置读/写（点号最多三层） |
+| `I($path, $once)` | 条件包含文件 |
+| `L($msg, $ctx, $level, $wf)` | 写日志 |
+| `T($e, $offset)` | 格式化异常堆栈字符串 |
+| `E($prefix, $e)` | 记录带堆栈的错误日志 |
+| `DB($opts)` | 获取 Medoo 实例 |
+| `json_output($msg, $code, $data)` | 输出 `{code,msg,data}` JSON 并退出 |
+| `redirect($url, $time, $msg)` | HTTP 重定向或 meta-refresh |
+| `html_filter($html)` | 过滤 script/iframe/onclick/style |
+| `strcut($str, $len, $ext, $zh_len)` | UTF-8 截断（含后缀） |
+| `generate_nonce_str($len)` | 随机字母数字字符串 |
+| `uuid($prefix)` | MD5 唯一 ID |
+| `authcode($str, $op, $key, $exp)` | Discuz 风格加解密 |
+| `signature($data, $key)` | MD5 参数签名 |
+| `curl_get_contents($url, $post, ...)` | cURL HTTP 请求 |
+| `get_client_ip($type)` | 获取真实客户端 IP |
+| `is_weixin_browser()` | 微信浏览器检测 |
+| `money_yuan_to_fen($price)` | 元（浮点）→ 分（整数） |
+| `money_fen_to_yuan($price)` | 分（整数）→ 元（浮点） |
+| `export_csv($filename, $data)` | 生成并下载 CSV |
+| `dump($var, ...)` | 格式化打印变量 |
+| `dump_with_exit(...)` | 格式化打印后退出 |
+| `human_date($ts, $fmt)` | 相对时间（"2 小时前"） |
+| `str_starts_with()` / `str_ends_with()` | PHP 8.0 polyfill |
+
+---
+
+## 开发命令
+
+```bash
+# 安装依赖
+composer install
+
+# 运行全部测试
+./vendor/bin/phpunit tests/
+
+# 运行单个测试文件
+./vendor/bin/phpunit tests/RouterTest.php
+
+# 静态分析
+./vendor/bin/phpstan analyse
+
+# 构建单文件发布产物（dist/Plume.php）
+composer build
+```
+
+---
+
+## 目录结构
+
+```
+library/
+  PlumePHP.php          # 引导入口 + 全局函数 + 静态门面
+  PlumeHelper.php       # 静态工具类
+  common.php            # 全局函数别名 → PlumeHelper
+  Plume/
+    Engine/             # 核心类（Router、Event、Loader、Container…）
+    Http/               # HTTP 层（Request、Response、Router、Route）
+    Support/            # 服务与工具（Logger、View、Param、Schema…）
+  core/Plume/Libs/      # 内置第三方库（Medoo、Curl、Action…）
+dist/
+  Plume.php             # 单文件发布产物（composer build 生成）
+public/
+  index.php             # Web 入口
+  worker.php            # FrankenPHP Worker 入口
+application/            # 业务代码（模块/Action/视图/命令）
+config/                 # 配置文件
+storage/log/            # 日志目录
 ```


### PR DESCRIPTION
## 变更摘要

- 补充静态门面写法（`PlumePHP::`）与 `$app` 实例写法的对比说明，解释两者在事件过滤器上的差异
- 新增路由正则缓存（`enableRouteCache`）用法
- 新增 PSR-15 中间件（`addMiddleware`）章节及示例
- 新增 PSR-11 容器（`container / bind / bindFactory`）章节
- 补充日志增强功能：`setFormatter`（text/json）、`setMode`（normal/batch）、`addHandler` 以及内置 `PlumeLogHandlers`（钉钉、Sentry）
- 新增 `PlumeSchema` 与 `PlumeJsonMapper` 用法说明
- 完善 FrankenPHP Worker 模式入口（`public/worker.php`）及注意事项
- 补全配置项表格、辅助函数参考表、Action 方法参考表
- 新增完整的目录结构说明

## 测试说明

- 文档变更，无需运行测试
- 所有代码示例均与当前 `library/` 源码核对一致

---
_Generated by [Claude Code](https://claude.ai/code/session_0164krfqhPCfBN1WUjWswpQk)_