### PR TITLE
security: fix critical/high/medium vulnerabilities (authcode AES-256-GCM, CSRF timing, cookies, UUID, logging)

### DIFF
--- a/library/Plume/Engine/ActionInvoker.php
+++ b/library/Plume/Engine/ActionInvoker.php
@@ -44,7 +44,32 @@ class ActionInvoker
      */
     public static function sanitizeForLog(array $request): array
     {
-        static $sensitive = ['password', 'passwd', 'pass', 'token', 'secret', 'card_no', 'cvv'];
-        return array_diff_key($request, array_flip($sensitive));
+        static $sensitive = [
+            // Credentials
+            'password', 'passwd', 'pass', 'pwd', 'new_password', 'old_password', 'confirm_password',
+            // Tokens & keys
+            'token', 'secret', 'api_key', 'apikey', 'access_token', 'refresh_token',
+            'auth_token', 'session_token', 'csrf_token', 'plume_csrf',
+            // Payment
+            'card_no', 'card_number', 'cvv', 'cvc', 'expiry', 'bank_account', 'bank_card',
+            // PII
+            'id_card', 'id_number', 'ssn', 'social_security', 'passport', 'license_number',
+            'phone', 'mobile', 'email', 'birthday', 'date_of_birth',
+            // Private keys
+            'private_key', 'encryption_key', 'signing_key',
+        ];
+        $result = array_diff_key($request, array_flip($sensitive));
+        // Also redact any key containing these substrings (case-insensitive)
+        $patterns = ['pass', 'secret', 'token', 'key', 'card', 'cvv', 'ssn', 'id_card'];
+        foreach ($result as $k => $v) {
+            $lower = strtolower((string) $k);
+            foreach ($patterns as $pattern) {
+                if (str_contains($lower, $pattern)) {
+                    $result[$k] = '***REDACTED***';
+                    break;
+                }
+            }
+        }
+        return $result;
     }
 }

--- a/library/Plume/Engine/Engine.php
+++ b/library/Plume/Engine/Engine.php
@@ -147,6 +147,14 @@ class PlumeEngine
             // session for every request after calling resetForWorker().
             if (!IS_CLI && true === C('USE_SESSION') && PHP_SESSION_NONE === session_status()
                 && !headers_sent()) {
+                $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+                    || (($_SERVER['SERVER_PORT'] ?? '') === '443');
+                ini_set('session.cookie_httponly', '1');
+                ini_set('session.use_strict_mode', '1');
+                ini_set('session.cookie_samesite', 'Lax');
+                if ($isHttps) {
+                    ini_set('session.cookie_secure', '1');
+                }
                 session_start();
             }
 
@@ -535,20 +543,16 @@ class PlumeEngine
         }
 
         if ('production' === $this->get('plumephp.env')) {
-            $msg = sprintf(
-                '<h1>500 Internal Server Error</h1>'.
-                '<h3>%s (%s)</h3>',
-                $e->getMessage(),
-                $e->getCode()
-            );
+            $msg = '<h1>500 Internal Server Error</h1>'
+                . '<p>An unexpected error occurred. Please try again later.</p>';
         } else {
             $msg = sprintf(
                 '<h1>500 Internal Server Error</h1>'.
                 '<h3>%s (%s)</h3>'.
                 '<pre>%s</pre>',
-                $e->getMessage(),
-                $e->getCode(),
-                $e->getTraceAsString()
+                htmlspecialchars($e->getMessage(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                htmlspecialchars((string) $e->getCode(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'),
+                htmlspecialchars($e->getTraceAsString(), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8')
             );
         }
 
@@ -690,10 +694,17 @@ class PlumeEngine
             throw new \Exception('Wrong parameter format, missing path');
         }
 
-        // Special character processing
-        $bizPath = str_replace('..', '', (string) $bizPathRaw);
-        $bizPath = str_replace('/', '', $bizPath);
-        $bizPath = str_replace('\\', '', $bizPath);
+        // Validate path using a whitelist: only alphanumerics, underscores, hyphens, and dots
+        $bizPath = (string) $bizPathRaw;
+        if (!preg_match('/^[a-zA-Z0-9_\-\.]+$/', $bizPath)) {
+            throw new \Exception('Wrong parameter format, invalid characters in path');
+        }
+        // Prevent path traversal segments
+        foreach (explode('.', $bizPath) as $segment) {
+            if ($segment === '' || $segment === '..') {
+                throw new \Exception('Wrong parameter format, invalid path segment');
+            }
+        }
         $names = explode('.', $bizPath, 20);
         $count = count($names);
         if ($count < 2) {

--- a/library/Plume/Http/Router.php
+++ b/library/Plume/Http/Router.php
@@ -154,7 +154,7 @@ class PlumeRouter
         }
         $cacheDir = dirname($this->cacheFile);
         if (!is_dir($cacheDir)) {
-            mkdir($cacheDir, 0755, true);
+            mkdir($cacheDir, 0700, true);
         }
         $tmp = $this->cacheFile . '.' . getmypid() . '.tmp';
         file_put_contents(

--- a/library/Plume/Support/Logger.php
+++ b/library/Plume/Support/Logger.php
@@ -36,7 +36,7 @@ class PlumeLogger implements \Psr\Log\LoggerInterface
             $this->logPath = C('PLUME_LOG_PATH') ?: LOG_PATH;
         }
         if (!is_dir($this->logPath)) {
-            mkdir($this->logPath, 0755, true);
+            mkdir($this->logPath, 0700, true);
         }
 
         // Flush buffered DEBUG/INFO/NOTICE logs on shutdown so fatal errors

--- a/library/Plume/Support/View.php
+++ b/library/Plume/Support/View.php
@@ -135,7 +135,7 @@ class PlumeView
             ? $this->getCompiledTemplate($this->content)
             : $this->content;
 
-        extract($this->vars);
+        extract($this->vars, EXTR_SKIP);
         if ('' === $layout || false === $layout) {
             include $includeFile;
         } else {

--- a/library/PlumeHelper.php
+++ b/library/PlumeHelper.php
@@ -128,22 +128,30 @@ class PlumeHelper
 
     public static function redirect(string $url, int $time = 0, string $msg = ''): never
     {
-        $url = str_replace(["\n", "\r"], '', $url);
+        $url = str_replace(["\n", "\r", "\0"], '', $url);
+
+        // Block javascript: and data: URIs which cannot be safe redirect targets
+        if (preg_match('/^\s*(?:javascript|data|vbscript):/i', $url)) {
+            $url = '/';
+        }
+
         if (empty($msg)) {
-            $msg = "系统将在{$time}秒之后自动跳转到{$url}！";
+            $escapedUrl = htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $msg        = "系统将在{$time}秒之后自动跳转到{$escapedUrl}！";
         }
         if (!headers_sent()) {
             if (0 === $time) {
                 header('Location: ' . $url);
             } else {
                 header("refresh:{$time};url={$url}");
-                echo $msg;
+                echo htmlspecialchars($msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             }
             exit();
         } else {
-            $str = "<meta http-equiv='Refresh' content='{$time};URL={$url}'>";
+            $safeUrl = htmlspecialchars($url, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+            $str     = "<meta http-equiv='Refresh' content='{$time};URL={$safeUrl}'>";
             if ($time != 0) {
-                $str .= $msg;
+                $str .= htmlspecialchars($msg, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
             }
             exit($str);
         }
@@ -245,7 +253,7 @@ class PlumeHelper
                 $tmp[] = $k . '=' . $v;
             }
         }
-        return md5(implode('&', $tmp) . '&key=' . $key);
+        return hash_hmac('sha256', implode('&', $tmp), $key);
     }
 
     public static function htmlFilter(string $html): string
@@ -260,56 +268,56 @@ class PlumeHelper
     }
 
     /**
-     * @deprecated since PlumePHP 1.4.0 — uses MD5-based RC4 stream cipher (Discuz legacy).
-     *   Replace with sodium_crypto_secretbox() or openssl_encrypt('AES-256-GCM', ...).
-     *   This function will be removed in a future major version.
+     * Encrypt or decrypt a string using AES-256-GCM (authenticated encryption).
+     *
+     * Encoding: base64url(nonce[12] + tag[16] + ciphertext) for ENCODE,
+     * or the same layout for DECODE.
+     *
+     * The $expiry parameter is embedded as a 10-digit Unix timestamp prefix
+     * inside the plaintext (0 = no expiry), preserving backward-compatible
+     * semantics with the legacy RC4-based implementation this replaced.
+     *
+     * @param string $string    Plaintext (ENCODE) or ciphertext (DECODE)
+     * @param string $operation 'ENCODE' or 'DECODE'
+     * @param string $key       Secret key (min 16 chars); falls back to APP_SECRET
+     * @param int    $expiry    Seconds until the token expires (0 = forever)
+     * @return string Ciphertext on ENCODE, plaintext on DECODE, '' on failure
      */
     public static function authcode(string $string, string $operation = 'DECODE', string $key = '', int $expiry = 0): string
     {
-        $ckeyLength = 4;
-        $key        = md5($key ?: 'plumephp');
-        $keya       = md5(substr($key, 0, 16));
-        $keyb       = md5(substr($key, 16, 16));
-        // @phpstan-ignore-next-line ($ckeyLength is intentionally a constant 4 here)
-        $keyc       = $ckeyLength
-            ? ($operation == 'DECODE' ? substr($string, 0, $ckeyLength) : substr(md5(microtime()), -$ckeyLength))
-            : '';
-        $cryptkey   = $keya . md5($keya . $keyc);
-        $keyLength  = strlen($cryptkey);
-        $string     = $operation == 'DECODE'
-            ? base64_decode(substr($string, $ckeyLength))
-            : sprintf('%010d', $expiry ? $expiry + time() : 0) . substr(md5($string . $keyb), 0, 16) . $string;
-        $stringLength = strlen($string);
-        $result = '';
-        $box    = range(0, 255);
-        $rndkey = [];
-        for ($i = 0; $i <= 255; $i++) {
-            $rndkey[$i] = ord($cryptkey[$i % $keyLength]);
-        }
-        for ($j = $i = 0; $i < 256; $i++) {
-            $j       = ($j + $box[$i] + $rndkey[$i]) % 256;
-            $tmp     = $box[$i];
-            $box[$i] = $box[$j];
-            $box[$j] = $tmp;
-        }
-        for ($a = $j = $i = 0; $i < $stringLength; $i++) {
-            $a       = ($a + 1) % 256;
-            $j       = ($j + $box[$a]) % 256;
-            $tmp     = $box[$a];
-            $box[$a] = $box[$j];
-            $box[$j] = $tmp;
-            $result .= chr((int)(ord($string[$i]) ^ ($box[($box[$a] + $box[$j]) % 256])));
-        }
-        if ($operation == 'DECODE') {
-            $expireTs = (int) substr($result, 0, 10);
-            if (($expireTs === 0 || $expireTs - time() > 0)
-                && substr($result, 10, 16) == substr(md5(substr($result, 26) . $keyb), 0, 16)
-            ) {
-                return substr($result, 26);
+        $rawKey = $key ?: (string) getenv('APP_SECRET') ?: 'plumephp-insecure-fallback-key!!';
+        // Derive a 256-bit key via SHA-256 so any key length is accepted safely
+        $derivedKey = hash('sha256', $rawKey, true);
+
+        if (strtoupper($operation) === 'ENCODE') {
+            $expireTs  = $expiry > 0 ? sprintf('%010d', time() + $expiry) : '0000000000';
+            $plaintext = $expireTs . $string;
+            $nonce     = random_bytes(12);
+            $tag       = '';
+            $cipher    = openssl_encrypt($plaintext, 'aes-256-gcm', $derivedKey, OPENSSL_RAW_DATA, $nonce, $tag, '', 16);
+            if ($cipher === false) {
+                return '';
             }
+            return rtrim(strtr(base64_encode($nonce . $tag . $cipher), '+/', '-_'), '=');
+        }
+
+        // DECODE
+        $raw = base64_decode(strtr($string, '-_', '+/') . str_repeat('=', (4 - strlen($string) % 4) % 4), true);
+        if ($raw === false || strlen($raw) < 29) { // 12 nonce + 16 tag + 1 min payload
             return '';
         }
-        return $keyc . str_replace('=', '', base64_encode($result));
+        $nonce  = substr($raw, 0, 12);
+        $tag    = substr($raw, 12, 16);
+        $cipher = substr($raw, 28);
+        $plain  = openssl_decrypt($cipher, 'aes-256-gcm', $derivedKey, OPENSSL_RAW_DATA, $nonce, $tag);
+        if ($plain === false) {
+            return '';
+        }
+        $expireTs = (int) substr($plain, 0, 10);
+        if ($expireTs !== 0 && $expireTs < time()) {
+            return '';
+        }
+        return substr($plain, 10);
     }
 
     // -----------------------------------------------------------------------
@@ -335,10 +343,20 @@ class PlumeHelper
 
     public static function uuid(string $prefix = ''): string
     {
-        $time  = md5(microtime());
-        $rand1 = md5(substr($time, rand(0, 10), rand(22, 32)));
-        $rand2 = md5(substr($rand1, rand(0, 10), rand(22, 32)));
-        return strtolower(md5($prefix . uniqid($prefix) . $time . $rand1 . $rand2));
+        $bytes = random_bytes(16);
+        // Set version 4 (random) and variant bits per RFC 4122
+        $bytes[6] = chr((ord($bytes[6]) & 0x0f) | 0x40);
+        $bytes[8] = chr((ord($bytes[8]) & 0x3f) | 0x80);
+        $hex = bin2hex($bytes);
+        $uuid = sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hex, 0, 8),
+            substr($hex, 8, 4),
+            substr($hex, 12, 4),
+            substr($hex, 16, 4),
+            substr($hex, 20, 12)
+        );
+        return $prefix ? $prefix . '-' . $uuid : $uuid;
     }
 
     public static function strcut(string $str, int $len, string $ext = '', int $zhLen = 0): string

--- a/library/core/Plume/Libs/Action.php
+++ b/library/core/Plume/Libs/Action.php
@@ -196,8 +196,8 @@ abstract class Action
 
         $this->csrfToken = $this->getCookie($this->csrfTokenKey);
         if ($this->csrfValidate && C('PLUME_PHP_ENV') !== 'testing' && !$this->validateCsrfToken()) {
-            header('HTTP/1.1 401 Unauthorized');
-            $this->error("Unauthorized");
+            header('HTTP/1.1 403 Forbidden');
+            $this->error("Forbidden");
         }
 
         $this->createCsrfToken();
@@ -485,15 +485,35 @@ EOF;
 
     /**
      * Set a cookie on the response.
-     * @param string $key    Cookie name
-     * @param string $value  Cookie value
-     * @param int    $expire Lifetime in seconds (default 86400)
-     * @param string $path   Cookie path
-     * @param string $domain Cookie domain
+     * @param string $key      Cookie name
+     * @param string $value    Cookie value
+     * @param int    $expire   Lifetime in seconds (default 86400)
+     * @param string $path     Cookie path
+     * @param string $domain   Cookie domain
+     * @param bool   $httpOnly Prevent JavaScript access (default true)
+     * @param bool   $secure   Transmit over HTTPS only (default auto-detected)
+     * @param string $sameSite SameSite policy: 'Strict', 'Lax', or 'None' (default 'Lax')
      */
-    public function setCookie(string $key, string $value, int $expire = 86400, string $path = '/', string $domain = ''): void
-    {
-        setcookie($key, $value, time() + $expire, $path, $domain);
+    public function setCookie(
+        string $key,
+        string $value,
+        int $expire = 86400,
+        string $path = '/',
+        string $domain = '',
+        bool $httpOnly = true,
+        bool $secure = false,
+        string $sameSite = 'Lax'
+    ): void {
+        $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
+            || (($_SERVER['SERVER_PORT'] ?? '') === '443');
+        setcookie($key, $value, [
+            'expires'  => time() + $expire,
+            'path'     => $path,
+            'domain'   => $domain,
+            'secure'   => $secure || $isHttps,
+            'httponly' => $httpOnly,
+            'samesite' => $sameSite,
+        ]);
     }
 
     /**
@@ -629,7 +649,7 @@ EOF;
             $mask = str_pad($mask, $n2, $n1 === 0 ? ' ' : $mask);
         }
         $token = $mask ^ $token;
-        return $token === $trueToken;
+        return hash_equals($trueToken, $token);
     }
 
     protected function beforeRun(): bool

--- a/library/core/Plume/Libs/Action.php
+++ b/library/core/Plume/Libs/Action.php
@@ -485,14 +485,14 @@ EOF;
 
     /**
      * Set a cookie on the response.
-     * @param string $key      Cookie name
-     * @param string $value    Cookie value
-     * @param int    $expire   Lifetime in seconds (default 86400)
-     * @param string $path     Cookie path
-     * @param string $domain   Cookie domain
-     * @param bool   $httpOnly Prevent JavaScript access (default true)
-     * @param bool   $secure   Transmit over HTTPS only (default auto-detected)
-     * @param string $sameSite SameSite policy: 'Strict', 'Lax', or 'None' (default 'Lax')
+     * @param string                            $key      Cookie name
+     * @param string                            $value    Cookie value
+     * @param int                               $expire   Lifetime in seconds (default 86400)
+     * @param string                            $path     Cookie path
+     * @param string                            $domain   Cookie domain
+     * @param bool                              $httpOnly Prevent JavaScript access (default true)
+     * @param bool                              $secure   Transmit over HTTPS only (default auto-detected)
+     * @param 'Lax'|'lax'|'Strict'|'strict'|'None'|'none' $sameSite SameSite policy (default 'Lax')
      */
     public function setCookie(
         string $key,
@@ -506,14 +506,18 @@ EOF;
     ): void {
         $isHttps = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off')
             || (($_SERVER['SERVER_PORT'] ?? '') === '443');
-        setcookie($key, $value, [
+        /** @var array{expires: int, path: string, domain: string, secure: bool, httponly: bool, samesite: 'Lax'|'lax'|'Strict'|'strict'|'None'|'none'} $options */
+        $options = [
             'expires'  => time() + $expire,
             'path'     => $path,
             'domain'   => $domain,
             'secure'   => $secure || $isHttps,
             'httponly' => $httpOnly,
-            'samesite' => $sameSite,
-        ]);
+            'samesite' => in_array($sameSite, ['Lax', 'lax', 'Strict', 'strict', 'None', 'none'], true)
+                ? $sameSite
+                : 'Lax',
+        ];
+        setcookie($key, $value, $options);
     }
 
     /**

--- a/tests/PlumeHelperTest.php
+++ b/tests/PlumeHelperTest.php
@@ -94,16 +94,25 @@ class PlumeHelperTest extends \PHPUnit\Framework\TestCase
     // Data / String
     // -----------------------------------------------------------------------
 
-    public function testUuidIsLowerHex(): void
+    public function testUuidIsRfc4122(): void
     {
         $id = PlumeHelper::uuid();
-        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $id);
+        // RFC 4122 v4 format: xxxxxxxx-xxxx-4xxx-[89ab]xxx-xxxxxxxxxxxx
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $id
+        );
     }
 
     public function testUuidWithPrefix(): void
     {
         $id = PlumeHelper::uuid('usr');
-        $this->assertMatchesRegularExpression('/^[0-9a-f]+$/', $id);
+        $this->assertStringStartsWith('usr-', $id);
+        $uuid = substr($id, 4);
+        $this->assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/',
+            $uuid
+        );
     }
 
     public function testStrcut(): void


### PR DESCRIPTION
## Summary

本 PR 对 PlumePHP 框架进行了全面安全加固，修复了代码审计中发现的所有 Critical、High、Medium 级别漏洞，335 个测试全部通过。

---

## 修复详情

### 立即修复（Critical / High）

| 文件 | 问题 | 修复 |
|------|------|------|
| `library/core/Plume/Libs/Action.php` | CSRF token 最终比较使用 `===`，存在时序攻击 | 改为 `hash_equals()` 常量时间比较 |
| `library/core/Plume/Libs/Action.php` | `setCookie()` 缺少 HttpOnly / Secure / SameSite | 新增三个安全属性参数，HTTPS 自动启用 Secure |
| `library/core/Plume/Libs/Action.php` | CSRF 验证失败返回 401 语义错误 | 改为 403 Forbidden |
| `library/Plume/Engine/Engine.php` | 生产环境 500 错误泄露 `getMessage()` / `getCode()` | 生产环境返回通用提示，开发环境输出经 `htmlspecialchars` 转义 |
| `library/Plume/Engine/Engine.php` | `session_start()` 前未设置安全 ini | 新增 `httponly` / `use_strict_mode` / `samesite` / HTTPS `secure` 配置 |
| `library/Plume/Engine/Engine.php` | BIZ 路径用黑名单过滤（`str_replace('..')`），可绕过 | 改为白名单正则 `/^[a-zA-Z0-9_\-\.]+$/` + 逐 segment 校验 |
| `library/PlumeHelper.php` | `signature()` 使用 MD5，可被碰撞伪造 | 替换为 `hash_hmac('sha256', ...)` |
| `library/PlumeHelper.php` | `uuid()` 使用 `rand()` / `uniqid()` / `md5()`，熵不足 | 使用 `random_bytes(16)` 生成符合 RFC 4122 v4 的 UUID |
| `library/PlumeHelper.php` | `authcode()` 使用废弃的 MD5 + RC4 流加密（Discuz 遗产） | 替换为 **AES-256-GCM** 认证加密，SHA-256 密钥派生，保留 `$expiry` 语义兼容性 |
| `library/PlumeHelper.php` | `redirect()` 未过滤 `javascript:` / `data:` URI，输出未转义 | 拦截危险协议，对 HTML 输出做 `htmlspecialchars` 转义 |

### 计划修复（Medium / Low）

| 文件 | 问题 | 修复 |
|------|------|------|
| `library/Plume/Engine/ActionInvoker.php` | 日志敏感字段过滤列表过少（仅 7 个） | 扩充至涵盖 PII、支付、密钥等 30+ 字段，并增加子串模糊匹配兜底 |
| `library/Plume/Support/Logger.php` | 日志目录权限 `0755`（世界可读） | 改为 `0700`（仅属主可读写） |
| `library/Plume/Http/Router.php` | 路由缓存目录权限 `0755` | 改为 `0700` |
| `library/Plume/Support/View.php` | `extract()` 无标志，外部变量可覆盖内置变量 | 添加 `EXTR_SKIP` 标志 |

---

## 兼容性说明

- **`authcode()` 破坏性变更**：新实现（AES-256-GCM）与旧实现（RC4）的密文格式**不兼容**。若应用中有旧密文存储在数据库/Cookie 中，需要在部署前完成数据迁移。
- **`uuid()` 格式变更**：返回值由 32 位纯 hex 改为标准 UUID 格式（`xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx`），带前缀时格式为 `prefix-uuid`。已更新对应测试。
- **`signature()` 破坏性变更**：输出由 MD5 hex（32 位）改为 HMAC-SHA256 hex（64 位）。若与外部系统（如微信支付）对接需要 MD5 签名，请在调用方自行使用 `md5()`。
- **`setCookie()` 新增参数**：新增 `$httpOnly`、`$secure`、`$sameSite` 参数，默认值向后兼容（`true`, auto, `'Lax'`）。

## Test plan

- [x] `./vendor/bin/phpunit tests/ --no-coverage` — 335 tests, 555 assertions, all passing
- [ ] 验证 HTTPS 环境下 Cookie 正确携带 Secure 标志
- [ ] 验证 `authcode()` ENCODE/DECODE 往返加解密正确
- [ ] 验证 BIZ 路径含 `..` 时正确抛出异常
- [ ] 验证生产模式（`plumephp.env=production`）500 页面不暴露错误细节

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KbNQpz52cgzdcqPw3fhYbD

---
_Generated by [Claude Code](https://claude.ai/code/session_01KbNQpz52cgzdcqPw3fhYbD)_